### PR TITLE
Build regex from channel and not sub->channel.

### DIFF
--- a/zcm/blocking.cpp
+++ b/zcm/blocking.cpp
@@ -489,7 +489,7 @@ zcm_sub_t* zcm_blocking_t::subscribe(const string& channel,
     sub->usr = usr;
     sub->regex = isRegexChannel(channel);
     if (sub->regex) {
-        sub->regexobj = (void*) new std::regex(sub->channel);
+        sub->regexobj = (void*) new std::regex(channel);
         ZCM_ASSERT(sub->regexobj);
         subsRegex[channel].push_back(sub);
     } else {


### PR DESCRIPTION
The sub->channel is a shortened string clipped at ZCM_CHANNEL_MAXLEN=32 while channel is the full string.